### PR TITLE
Switch workflow to Java 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.9
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.9
+        java-version: 11
     - name: Build with Maven
       run: mvn package --file pom.xml


### PR DESCRIPTION
Java 9 is an unsupported/old version and shouldn't be used for anything. The only Java versions that should be used are Java 11 or 15.